### PR TITLE
feat: add CraftEngine scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ If you encounter any issues or have feature requests, please open an issue on Gi
 
 Happy farming! 🌾🍽
 
+## CraftEngine Migration (Experimental)
+
+This repository now contains a minimal scaffolding for a future **CraftEngine**
+port. The `CraftEngineFarmersDelight` entry uses a simple furniture block
+storage to register modelled blocks that can be interacted with. An example
+model configuration is provided at
+`src/main/resources/craftengine/models/stove.json`.
+

--- a/src/main/kotlin/fr/ateastudio/farmersdelight/craftengine/CraftEngineAddon.kt
+++ b/src/main/kotlin/fr/ateastudio/farmersdelight/craftengine/CraftEngineAddon.kt
@@ -1,0 +1,11 @@
+package fr.ateastudio.farmersdelight.craftengine
+
+/**
+ * Minimal stub representing a CraftEngine addon.
+ * This placeholder exists to aid transition from Nova.
+ * Replace with the real CraftEngine API when available.
+ */
+open class CraftEngineAddon {
+    open fun onEnable() {}
+    open fun onDisable() {}
+}

--- a/src/main/kotlin/fr/ateastudio/farmersdelight/craftengine/CraftEngineFarmersDelight.kt
+++ b/src/main/kotlin/fr/ateastudio/farmersdelight/craftengine/CraftEngineFarmersDelight.kt
@@ -1,0 +1,18 @@
+package fr.ateastudio.farmersdelight.craftengine
+
+/**
+ * Entry point for the CraftEngine edition of Farmer's Delight.
+ * Registers an example modelled furniture block.
+ */
+object CraftEngineFarmersDelight : CraftEngineAddon() {
+
+    override fun onEnable() {
+        // Example registration; replace with actual blocks.
+        FurnitureBlockStorage.register(
+            ModelledFurnitureBlock(
+                id = "farmersdelight:stove",
+                model = "craftengine:furniture/stove"
+            )
+        )
+    }
+}

--- a/src/main/kotlin/fr/ateastudio/farmersdelight/craftengine/ModelledFurnitureBlock.kt
+++ b/src/main/kotlin/fr/ateastudio/farmersdelight/craftengine/ModelledFurnitureBlock.kt
@@ -1,0 +1,30 @@
+package fr.ateastudio.farmersdelight.craftengine
+
+/**
+ * Simple representation of a furniture block backed by CraftEngine's
+ * storage system. The block keeps track of a model identifier and allows
+ * invocation of custom interaction handlers.
+ */
+class ModelledFurnitureBlock(
+    val id: String,
+    val model: String,
+    private val onInteract: (() -> Unit)? = null
+) {
+
+    fun interact() {
+        onInteract?.invoke()
+    }
+}
+
+/**
+ * In-memory registry for modelled furniture blocks.
+ */
+object FurnitureBlockStorage {
+    private val blocks = mutableMapOf<String, ModelledFurnitureBlock>()
+
+    fun register(block: ModelledFurnitureBlock) {
+        blocks[block.id] = block
+    }
+
+    fun get(id: String): ModelledFurnitureBlock? = blocks[id]
+}

--- a/src/main/resources/craftengine/models/stove.json
+++ b/src/main/resources/craftengine/models/stove.json
@@ -1,0 +1,8 @@
+{
+  "id": "farmersdelight:stove",
+  "model": "craftengine:furniture/stove",
+  "interactions": {
+    "use": "cook",
+    "break": "drop_contents"
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder CraftEngine addon and furniture block storage
- register example stove model and expose sample config
- document experimental CraftEngine migration

## Testing
- `./gradlew test` *(failed: build process was terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f5fe4f0083309bd1f73975d09092